### PR TITLE
Add combined token delete mutation

### DIFF
--- a/api/juno/api/delete_tokens_mutation.py
+++ b/api/juno/api/delete_tokens_mutation.py
@@ -1,0 +1,25 @@
+import graphene
+from graphql_jwt.settings import jwt_settings
+
+# custom mutation combining graphql_jwt's functionality
+# - DeleteJSONWebTokenCookie
+# - DeleteRefreshTokenCookie
+
+
+class DeleteTokens(graphene.Mutation):
+
+    deleted = graphene.Boolean(required=True)
+
+    @classmethod
+    def mutate(cls, root, info, **kwargs):
+        context = info.context
+        context.delete_jwt_cookie = (
+            jwt_settings.JWT_COOKIE_NAME in context.COOKIES
+            and getattr(context, "jwt_cookie", False)
+        )
+        context.delete_refresh_token_cookie = (
+            jwt_settings.JWT_REFRESH_TOKEN_COOKIE_NAME in context.COOKIES
+            and getattr(context, "jwt_cookie", False)
+        )
+        return DeleteTokens(deleted=True)
+

--- a/api/juno/api/schema.py
+++ b/api/juno/api/schema.py
@@ -4,11 +4,10 @@ from graphql_jwt import (
     ObtainJSONWebToken,
     Verify,
     Refresh,
-    DeleteJSONWebTokenCookie,
 )
 from graphql_jwt.decorators import login_required
 
-
+from juno.api.delete_tokens_mutation import DeleteTokens
 from juno.api import models
 
 
@@ -35,7 +34,7 @@ class Mutation(object):
     token_auth = ObtainJSONWebToken.Field()
     verify_token = Verify.Field()
     refresh_token = Refresh.Field()
-    delete_token_cookie = DeleteJSONWebTokenCookie.Field()
+    delete_token_cookie = DeleteTokens.Field()
 
 
 class Query(object):


### PR DESCRIPTION
This PR replaces usage of `DeleteJSONWebTokenCookie` from `graphql_jwt` with a custom `DeleteTokens` mutation, which now deletes the refresh token as well. Previously, on refreshing the browser after logout, one would be logged in again.