### PR TITLE
Restrict samples by authentication

### DIFF
--- a/api/juno/api/management/commands/e2e.py
+++ b/api/juno/api/management/commands/e2e.py
@@ -62,7 +62,14 @@ class Command(BaseCommand):
             email="admin@sanger.ac.uk", first_name="Alice", last_name="Jones"
         )
         collaborator = User.objects.create(
-            email="collaborator@nrl.israel", first_name="Bob", last_name="Smith",
+            email="collaborator@nrl.israel",
+            first_name="Bob",
+            last_name="Smith",
+        )
+        collaborator_multiple = User.objects.create(
+            email="collaborator@multiple.com",
+            first_name="Howard",
+            last_name="Jenkins",
         )
 
         # institutions
@@ -90,6 +97,12 @@ class Command(BaseCommand):
         Affiliation.objects.create(
             user=collaborator, institution=nrl,
         )
+        Affiliation.objects.create(
+            user=collaborator_multiple, institution=nrl,
+        )
+        Affiliation.objects.create(
+            user=collaborator_multiple, institution=cuhk,
+        )
 
         # samples
         Sample.objects.create(
@@ -115,6 +128,14 @@ class Command(BaseCommand):
             serotype="VI",
             host_status="pneumonia",
             submitting_institution=cuhk,
+        )
+        Sample.objects.create(
+            lane_id="32820_2#368",
+            sample_id="5903STDY8113195",
+            public_name="JN_IL_ST31579",
+            serotype="V",
+            host_status="pneumonia",
+            submitting_institution=sanger,
         )
 
         # fix the passwords of users to be email prefix

--- a/api/juno/api/schema.py
+++ b/api/juno/api/schema.py
@@ -47,11 +47,41 @@ class Query(object):
     def resolve_me(self, info, **kwargs):
         return info.context.user
 
+    @login_required
     def resolve_samples(self, info, **kwargs):
         # TODO: add pagination
         # TODO: add filtering/sorting for columns
-        return models.Sample.objects.all()
 
+        # get user's affiliations
+        affiliations = info.context.user.affiliations
+
+        # sanger user's can see everything
+        if (
+            affiliations.filter(
+                name__exact="Wellcome Sanger Institute"
+            ).count()
+            > 0
+        ):
+            return models.Sample.objects.all()
+        else:
+            return models.Sample.objects.filter(
+                submitting_institution__affiliated_members__in=[
+                    info.context.user
+                ]
+            ).all()
+
+    @login_required
     def resolve_institutions(self, info, **kwargs):
-        # TODO: remove this (just for debug)
-        return models.Institution.objects.all()
+        # get user's affiliations
+        affiliations = info.context.user.affiliations
+
+        # sanger user's can see everything
+        if (
+            affiliations.filter(
+                name__exact="Wellcome Sanger Institute"
+            ).count()
+            > 0
+        ):
+            return models.Institution.objects.all()
+        else:
+            return affiliations.all()

--- a/api/juno/tests/base.py
+++ b/api/juno/tests/base.py
@@ -23,6 +23,9 @@ class GraphQLTestCase(TestCase):
     # common messages
     GRAPHQL_JWT_MSG_SIGNATURE_EXPIRED = "Signature has expired"
     GRAPHQL_JWT_MSG_REFRESH_TOKEN_EXPIRED = "Refresh token is expired"
+    GRAPHQL_JWT_MSG_BAD_PERMISSIONS = (
+        "You do not have permission to perform this action"
+    )
 
     MSG_ROOT_NOT_AN_OBJECT = "API response should be a JSON object"
     MSG_NO_DATA = "API response missing an expected data field"

--- a/api/juno/tests/test_query_institutions_restricted.py
+++ b/api/juno/tests/test_query_institutions_restricted.py
@@ -1,0 +1,120 @@
+from juno.tests.base import AuthenticatableGraphQLTestCase
+from juno.api.models import Institution, User, Affiliation
+
+
+class InstitutionsQueryTestCase(AuthenticatableGraphQLTestCase):
+    def setUp(self):
+        # put several institutions in the db
+        self.institution_sanger = Institution.objects.create(
+            name="Wellcome Sanger Institute",
+            country="United Kingdom",
+            latitude=52.083333,
+            longitude=0.183333,
+        )
+        self.institution_other = Institution.objects.create(
+            name="Monsters Inc",
+            country="Unknown",
+            latitude=34.3,
+            longitude=170.6,
+        )
+        self.institution_another = Institution.objects.create(
+            name="Skynet",
+            country="United States",
+            latitude=44.3,
+            longitude=223.2,
+        )
+
+        # put several users in the db
+        self.user_sanger = User.objects.create(
+            email="jane@sanger.ac.uk", first_name="Jane", last_name="Seymour",
+        )
+        self.password_sanger = "janesicles"
+        self.user_sanger.set_password(self.password_sanger)
+        self.user_sanger.save()
+        self.user_other = User.objects.create(
+            email="bob@bob.com", first_name="Bob", last_name="Bobbity",
+        )
+        self.password_other = "bobsicles"
+        self.user_other.set_password(self.password_other)
+        self.user_other.save()
+
+        # associate the users with the institutions
+        Affiliation.objects.create(
+            user=self.user_sanger, institution=self.institution_sanger
+        )
+        Affiliation.objects.create(
+            user=self.user_other, institution=self.institution_other
+        )
+
+    def make_and_validate_institutions_query(self, subquery):
+        # call api
+        response = self.make_query("institutions", subquery)
+        data = self.validate_successful(response)
+        institutions = self.validate_field(data, "institutions")
+
+        # check non-empty
+        self.validate_non_empty_list(institutions)
+
+        # return institutions
+        return institutions
+
+    def test_non_authenticated_user_cannot_view_institutions(self):
+        # call api
+        response = self.make_query("institutions", "name")
+
+        # checks
+        content = self.validate_unsuccessful(response)
+        errors = self.validate_has_graphql_errors(content)
+        self.assertTrue(
+            any(
+                e["message"] == self.GRAPHQL_JWT_MSG_BAD_PERMISSIONS
+                for e in errors
+            )
+        )
+        if (
+            "data" in content.keys()
+            and "institutions" in content["data"].keys()
+        ):
+            self.assertEqual(content["data"]["institutions"], None)
+
+    def test_non_sanger_user_can_view_restricted_institutions(self):
+        # login as non-sanger user
+        response = self.login(self.user_other.email, self.password_other)
+        self.validate_login_successful(response)
+
+        # call api
+        institutions = self.make_and_validate_institutions_query("name")
+
+        # checks
+        self.assertEqual(len(institutions), 1)
+        self.validate_field(
+            institutions[0],
+            "name",
+            expected_value=self.institution_other.name,
+        )
+
+    def test_sanger_user_can_view_all_institutions(self):
+        # login as sanger user
+        response = self.login(self.user_sanger.email, self.password_sanger)
+        self.validate_login_successful(response)
+
+        # call api
+        institutions = self.make_and_validate_institutions_query("name")
+
+        # checks
+        self.assertEqual(len(institutions), 3)
+        self.validate_field(
+            institutions[0],
+            "name",
+            expected_value=self.institution_sanger.name,
+        )
+        self.validate_field(
+            institutions[1],
+            "name",
+            expected_value=self.institution_other.name,
+        )
+        self.validate_field(
+            institutions[2],
+            "name",
+            expected_value=self.institution_another.name,
+        )

--- a/api/juno/tests/test_query_samples_restricted.py
+++ b/api/juno/tests/test_query_samples_restricted.py
@@ -1,0 +1,124 @@
+from juno.tests.base import AuthenticatableGraphQLTestCase
+from juno.api.models import Sample, Institution, User, Affiliation
+
+
+class SamplesQueryTestCase(AuthenticatableGraphQLTestCase):
+    def setUp(self):
+        # put several institutions in the db
+        self.institution_sanger = Institution.objects.create(
+            name="Wellcome Sanger Institute",
+            country="United Kingdom",
+            latitude=52.083333,
+            longitude=0.183333,
+        )
+        self.institution_other = Institution.objects.create(
+            name="Monsters Inc",
+            country="Unknown",
+            latitude=34.3,
+            longitude=170.6,
+        )
+        self.institution_another = Institution.objects.create(
+            name="Skynet",
+            country="United States",
+            latitude=44.3,
+            longitude=223.2,
+        )
+
+        # put several users in the db
+        self.user_sanger = User.objects.create(
+            email="jane@sanger.ac.uk", first_name="Jane", last_name="Seymour",
+        )
+        self.password_sanger = "janesicles"
+        self.user_sanger.set_password(self.password_sanger)
+        self.user_sanger.save()
+        self.user_other = User.objects.create(
+            email="bob@bob.com", first_name="Bob", last_name="Bobbity",
+        )
+        self.password_other = "bobsicles"
+        self.user_other.set_password(self.password_other)
+        self.user_other.save()
+
+        # associate the users with the institutions
+        Affiliation.objects.create(
+            user=self.user_sanger, institution=self.institution_sanger
+        )
+        Affiliation.objects.create(
+            user=self.user_other, institution=self.institution_other
+        )
+
+        # put a sample in the db per institution
+        self.sample_other = Sample.objects.create(
+            lane_id="31663_7#113",
+            sample_id="5903STDY8059170",
+            public_name="CUHK_GBS177WT_16",
+            serotype="Ia",
+            host_status="skin and soft-tissue infection",
+            submitting_institution=self.institution_other,
+        )
+        self.sample_another = Sample.objects.create(
+            lane_id="31663_7#114",
+            sample_id="5903STDY8059171",
+            public_name="CUHK_GBS177WT_17",
+            serotype="Ib",
+            host_status="skin and soft-tissue infection",
+            submitting_institution=self.institution_another,
+        )
+
+    def make_and_validate_samples_query(self, subquery):
+        # call api
+        response = self.make_query("samples", subquery)
+        data = self.validate_successful(response)
+        samples = self.validate_field(data, "samples")
+
+        # check non-empty
+        self.validate_non_empty_list(samples)
+
+        # return samples
+        return samples
+
+    def test_non_authenticated_user_cannot_view_samples(self):
+        # call api
+        response = self.make_query("samples", "laneId")
+
+        # checks
+        content = self.validate_unsuccessful(response)
+        errors = self.validate_has_graphql_errors(content)
+        self.assertTrue(
+            any(
+                e["message"] == self.GRAPHQL_JWT_MSG_BAD_PERMISSIONS
+                for e in errors
+            )
+        )
+        if "data" in content.keys() and "samples" in content["data"].keys():
+            self.assertEqual(content["data"]["samples"], None)
+
+    def test_non_sanger_user_can_view_restricted_samples(self):
+        # login as non-sanger user
+        response = self.login(self.user_other.email, self.password_other)
+        self.validate_login_successful(response)
+
+        # call api
+        samples = self.make_and_validate_samples_query("laneId")
+
+        # checks
+        self.assertEqual(len(samples), 1)
+        self.validate_field(
+            samples[0], "laneId", expected_value=self.sample_other.lane_id,
+        )
+
+    def test_sanger_user_can_view_all_samples(self):
+        # login as sanger user
+        response = self.login(self.user_sanger.email, self.password_sanger)
+        self.validate_login_successful(response)
+
+        # call api
+        samples = self.make_and_validate_samples_query("laneId")
+
+        # checks
+        self.assertEqual(len(samples), 2)
+        self.validate_field(
+            samples[0], "laneId", expected_value=self.sample_other.lane_id,
+        )
+        self.validate_field(
+            samples[1], "laneId", expected_value=self.sample_another.lane_id,
+        )

--- a/e2e/integration/sample-table.spec.js
+++ b/e2e/integration/sample-table.spec.js
@@ -49,9 +49,6 @@ describe("sample table", () => {
       db.sample.forEach(({ lane_id }) => {
         cy.get(`table#sampleTable`).contains("td", lane_id);
       });
-
-      // logout
-      logout();
     });
   });
 
@@ -65,14 +62,16 @@ describe("sample table", () => {
       const user = db.user[1];
       login(user.email);
 
-      // allowed institutions
-      const affiliations = db.affiliation.filter((d) => d.user === user.email);
-      const institutionsAllowed = affiliations.map((d) => d.institution);
+      // calculate allowed
+      const affiliations = db.affiliation.filter(
+        (d) => d.user_id === user.email
+      );
+      const institutionsAllowed = affiliations.map((d) => d.institution_id);
       const samplesAllowed = db.sample.filter(
-        (d) => institutionsAllowed.indexOf(d.submitting_institution) >= 0
+        (d) => institutionsAllowed.indexOf(d.submitting_institution_id) >= 0
       );
       const samplesDisallowed = db.sample.filter(
-        (d) => institutionsAllowed.indexOf(d.submitting_institution) < 0
+        (d) => institutionsAllowed.indexOf(d.submitting_institution_id) < 0
       );
 
       // some samples should be visible, some not?
@@ -88,9 +87,6 @@ describe("sample table", () => {
       samplesDisallowed.forEach(({ lane_id }) => {
         cy.get(`table#sampleTable`).contains("td", lane_id).should("not.exist");
       });
-
-      // logout
-      logout();
     });
   });
 });

--- a/e2e/integration/sample-table.spec.js
+++ b/e2e/integration/sample-table.spec.js
@@ -63,7 +63,7 @@ describe("sample table", () => {
       login(user.email);
 
       // allowed institutions
-      const affiliations = db.affiliations.filter((d) => d.user === user.email);
+      const affiliations = db.affiliation.filter((d) => d.user === user.email);
       const institutionsAllowed = affiliations.map((d) => d.institution);
       const samplesAllowed = db.sample.filter(
         (d) => institutionsAllowed.indexOf(d.submitting_institution) >= 0

--- a/e2e/integration/sample-table.spec.js
+++ b/e2e/integration/sample-table.spec.js
@@ -1,4 +1,4 @@
-import { DB_PROFILES, loadDatabaseProfile, login, logout } from "../utils";
+import { DB_PROFILES, loadDatabaseProfile, login } from "../utils";
 
 describe("sample table", () => {
   beforeEach(() => {
@@ -57,9 +57,10 @@ describe("sample table", () => {
       // non-empty samples table?
       expect(db.sample.length).to.be.greaterThan(0);
 
-      // login as collaborating user (can view subset of samples only)
+      // login as collaborating user (multiple affiliations)
+      // (can view subset of samples only)
       cy.visit("/");
-      const user = db.user[1];
+      const user = db.user[2];
       login(user.email);
 
       // calculate allowed
@@ -73,6 +74,10 @@ describe("sample table", () => {
       const samplesDisallowed = db.sample.filter(
         (d) => institutionsAllowed.indexOf(d.submitting_institution_id) < 0
       );
+
+      // some affiliations, but not all?
+      expect(institutionsAllowed.length).to.be.greaterThan(0);
+      expect(institutionsAllowed.length).to.be.lessThan(db.institution.length);
 
       // some samples should be visible, some not?
       expect(samplesAllowed.length).to.be.greaterThan(0);

--- a/e2e/integration/sample-table.spec.js
+++ b/e2e/integration/sample-table.spec.js
@@ -73,8 +73,8 @@ describe("sample table", () => {
       );
 
       // some samples should be visible, some not?
-      expect(samplesAllowed).to.be.greaterThan(0);
-      expect(samplesDisallowed).to.be.greaterThan(0);
+      expect(samplesAllowed.length).to.be.greaterThan(0);
+      expect(samplesDisallowed.length).to.be.greaterThan(0);
 
       // table contains allowed database entries?
       samplesAllowed.forEach(({ lane_id }) => {

--- a/e2e/integration/sample-table.spec.js
+++ b/e2e/integration/sample-table.spec.js
@@ -35,12 +35,12 @@ describe("sample table", () => {
     });
   });
 
-  it("is populated when the database is non-empty", () => {
+  it("is populated when the database is non-empty as sanger user", () => {
     loadDatabaseProfile(DB_PROFILES.SMALL).then((db) => {
       // non-empty samples table?
       expect(db.sample.length).to.be.greaterThan(0);
 
-      // login
+      // login as sanger user (can view all samples)
       cy.visit("/");
       const user = db.user[0];
       login(user.email);
@@ -48,6 +48,42 @@ describe("sample table", () => {
       // table contains database entries?
       db.sample.forEach(({ lane_id }) => {
         cy.get(`table#sampleTable`).contains("td", lane_id);
+      });
+    });
+  });
+
+  it("is populated when the database is non-empty as collaborator", () => {
+    loadDatabaseProfile(DB_PROFILES.SMALL).then((db) => {
+      // non-empty samples table?
+      expect(db.sample.length).to.be.greaterThan(0);
+
+      // login as collaborating user (can view subset of samples only)
+      cy.visit("/");
+      const user = db.user[1];
+      login(user.email);
+
+      // allowed institutions
+      const affiliations = db.affiliations.filter((d) => d.user === user.email);
+      const institutionsAllowed = affiliations.map((d) => d.institution);
+      const samplesAllowed = db.sample.filter(
+        (d) => institutionsAllowed.indexOf(d.submitting_institution) >= 0
+      );
+      const samplesDisallowed = db.sample.filter(
+        (d) => institutionsAllowed.indexOf(d.submitting_institution) < 0
+      );
+
+      // some samples should be visible, some not?
+      expect(samplesAllowed).to.be.greaterThan(0);
+      expect(samplesDisallowed).to.be.greaterThan(0);
+
+      // table contains allowed database entries?
+      samplesAllowed.forEach(({ lane_id }) => {
+        cy.get(`table#sampleTable`).contains("td", lane_id);
+      });
+
+      // table contains allowed database entries?
+      samplesDisallowed.forEach(({ lane_id }) => {
+        cy.get(`table#sampleTable`).contains("td", lane_id).should("not.exist");
       });
     });
   });

--- a/e2e/integration/sample-table.spec.js
+++ b/e2e/integration/sample-table.spec.js
@@ -1,4 +1,4 @@
-import { API_WAIT_MS, DB_PROFILES, loadDatabaseProfile, login } from "../utils";
+import { DB_PROFILES, loadDatabaseProfile, login, logout } from "../utils";
 
 describe("sample table", () => {
   beforeEach(() => {
@@ -49,6 +49,9 @@ describe("sample table", () => {
       db.sample.forEach(({ lane_id }) => {
         cy.get(`table#sampleTable`).contains("td", lane_id);
       });
+
+      // logout
+      logout();
     });
   });
 
@@ -85,6 +88,9 @@ describe("sample table", () => {
       samplesDisallowed.forEach(({ lane_id }) => {
         cy.get(`table#sampleTable`).contains("td", lane_id).should("not.exist");
       });
+
+      // logout
+      logout();
     });
   });
 });

--- a/e2e/integration/sample-table.spec.js
+++ b/e2e/integration/sample-table.spec.js
@@ -83,7 +83,7 @@ describe("sample table", () => {
         cy.get(`table#sampleTable`).contains("td", lane_id);
       });
 
-      // table contains allowed database entries?
+      // table does not contain disallowed database entries?
       samplesDisallowed.forEach(({ lane_id }) => {
         cy.get(`table#sampleTable`).contains("td", lane_id).should("not.exist");
       });

--- a/ui/src/AppProviders.test.js
+++ b/ui/src/AppProviders.test.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+
+import AppProviders from "./AppProviders";
+import { useAuth } from "./auth";
+import { useUser } from "./user";
+
+describe("AppProviders", () => {
+  // helper
+  const wrapper = ({ children }) => <AppProviders>{children}</AppProviders>;
+
+  it("should provide AuthContext", () => {
+    const { result } = renderHook(() => useAuth(), {
+      wrapper,
+    });
+
+    expect(result.current).toHaveProperty("isLoggedIn");
+    expect(result.current).toHaveProperty("isLoading");
+    expect(result.current).toHaveProperty("login");
+    expect(result.current).toHaveProperty("logout");
+  });
+
+  it("should provide UserContext", () => {
+    const { result } = renderHook(() => useUser(), {
+      wrapper,
+    });
+
+    expect(result.current).toHaveProperty("user");
+  });
+});

--- a/ui/src/auth.js
+++ b/ui/src/auth.js
@@ -22,8 +22,6 @@ export const REFRESH_MUTATION = gql`
   mutation RefreshToken {
     refreshToken {
       payload
-      token
-      refreshExpiresIn
     }
   }
 `;

--- a/ui/src/auth.test.js
+++ b/ui/src/auth.test.js
@@ -79,11 +79,16 @@ describe("RealAuthProvider", () => {
       await waitForNextUpdate();
     });
 
+    // query made?
+    expect(called.verifyMutation).toBeGreaterThan(0);
+    expect(called.refreshMutation).toBeGreaterThan(0);
+
+    // authenticated?
     expect(result.current.isLoggedIn).toBe(false);
   });
 
   it("should be logged in initially if auth token", async () => {
-    const { mocks: apiMocks } = generateApiMocks();
+    const { called, mocks: apiMocks } = generateApiMocks();
     const { result, waitForNextUpdate } = renderHook(() => useAuth(), {
       wrapper,
       initialProps: { apiMocks },
@@ -94,6 +99,11 @@ describe("RealAuthProvider", () => {
       await waitForNextUpdate();
     });
 
+    // query made?
+    expect(called.verifyMutation).toBeGreaterThan(0);
+    expect(called.refreshMutation).toBe(0);
+
+    // authenticated?
     expect(result.current.isLoggedIn).toBe(true);
   });
 
@@ -117,6 +127,11 @@ describe("RealAuthProvider", () => {
       await waitForNextUpdate();
     });
 
+    // query made?
+    expect(called.verifyMutation).toBeGreaterThan(0);
+    expect(called.refreshMutation).toBeGreaterThan(0);
+
+    // authenticated?
     expect(result.current.isLoggedIn).toBe(true);
   });
 
@@ -150,6 +165,8 @@ describe("RealAuthProvider", () => {
     });
 
     // query made?
+    expect(called.verifyMutation).toBeGreaterThan(0);
+    expect(called.refreshMutation).toBeGreaterThan(0);
     expect(called.loginMutation).toBeGreaterThan(0);
 
     // authenticated?
@@ -188,6 +205,8 @@ describe("RealAuthProvider", () => {
     });
 
     // query made?
+    expect(called.verifyMutation).toBeGreaterThan(0);
+    expect(called.refreshMutation).toBeGreaterThan(0);
     expect(called.loginMutation).toBeGreaterThan(0);
 
     // authenticated?
@@ -228,6 +247,9 @@ describe("RealAuthProvider", () => {
     });
 
     // query made?
+    expect(called.verifyMutation).toBeGreaterThan(0);
+    expect(called.refreshMutation).toBeGreaterThan(0);
+    expect(called.loginMutation).toBeGreaterThan(0);
     expect(called.logoutMutation).toBeGreaterThan(0);
 
     // authenticated?

--- a/ui/src/auth.test.js
+++ b/ui/src/auth.test.js
@@ -72,7 +72,10 @@ describe("RealAuthProvider", () => {
     });
 
     await act(async () => {
+      // verify
       await waitForNextUpdate();
+
+      // refresh
       await waitForNextUpdate();
     });
 
@@ -87,6 +90,7 @@ describe("RealAuthProvider", () => {
     });
 
     await act(async () => {
+      // verify
       await waitForNextUpdate();
     });
 
@@ -106,7 +110,10 @@ describe("RealAuthProvider", () => {
     });
 
     await act(async () => {
+      // verify
       await waitForNextUpdate();
+
+      // refresh
       await waitForNextUpdate();
     });
 
@@ -114,14 +121,27 @@ describe("RealAuthProvider", () => {
   });
 
   it("should be logged in after calling login", async () => {
-    const { called, mocks: apiMocks } = generateApiMocks();
+    const mocks = {
+      ...mockDefaults,
+      verify: null,
+      verifyErrors: [ERROR_NO_AUTH_TOKEN],
+      refresh: null,
+      refreshErrors: [ERROR_NO_REFRESH_TOKEN],
+    };
+    const { called, mocks: apiMocks } = generateApiMocks(mocks);
     const { result, waitForNextUpdate } = renderHook(() => useAuth(), {
       wrapper,
       initialProps: { apiMocks },
     });
 
     await act(async () => {
+      // verify
       await waitForNextUpdate();
+
+      // refresh
+      await waitForNextUpdate();
+
+      // login
       result.current.login({
         email: mockUser.email,
         password: mockUser.email.split("@")[0],
@@ -139,6 +159,10 @@ describe("RealAuthProvider", () => {
   it("should not be logged in after calling login unsuccessfully", async () => {
     const mocks = {
       ...mockDefaults,
+      verify: null,
+      verifyErrors: [ERROR_NO_AUTH_TOKEN],
+      refresh: null,
+      refreshErrors: [ERROR_NO_REFRESH_TOKEN],
       login: null,
       loginErrors: [ERROR_BAD_CREDENTIALS],
     };
@@ -149,7 +173,13 @@ describe("RealAuthProvider", () => {
     });
 
     await act(async () => {
+      // verify
       await waitForNextUpdate();
+
+      // refresh
+      await waitForNextUpdate();
+
+      // login
       result.current.login({
         email: mockUser.email,
         password: mockUser.email.split("@")[0],
@@ -165,19 +195,34 @@ describe("RealAuthProvider", () => {
   });
 
   it("should be logged out after calling login then logout", async () => {
-    const { called, mocks: apiMocks } = generateApiMocks();
+    const mocks = {
+      ...mockDefaults,
+      verify: null,
+      verifyErrors: [ERROR_NO_AUTH_TOKEN],
+      refresh: null,
+      refreshErrors: [ERROR_NO_REFRESH_TOKEN],
+    };
+    const { called, mocks: apiMocks } = generateApiMocks(mocks);
     const { result, waitForNextUpdate } = renderHook(() => useAuth(), {
       wrapper,
       initialProps: { apiMocks },
     });
 
     await act(async () => {
+      // verify
       await waitForNextUpdate();
+
+      // refresh
+      await waitForNextUpdate();
+
+      // login
       result.current.login({
         email: mockUser.email,
         password: mockUser.email.split("@")[0],
       });
       await waitForNextUpdate();
+
+      // logout
       result.current.logout();
       await waitForNextUpdate();
     });

--- a/ui/src/authFetchers.js
+++ b/ui/src/authFetchers.js
@@ -20,8 +20,6 @@ const REFRESH_TOKEN_MUTATION = `
   mutation RefreshToken {
     refreshToken {
       payload
-      token
-      refreshExpiresIn
     }
   }
 `;

--- a/ui/src/client.js
+++ b/ui/src/client.js
@@ -45,9 +45,6 @@ export const handleBadPermissions = () =>
             }
           });
       }
-    })
-    .catch((error) => {
-      console.error("Failed to handle bad permissions.", error);
     });
 
 const errorLink = onError(({ graphQLErrors, forward, operation }) => {

--- a/ui/src/client.js
+++ b/ui/src/client.js
@@ -16,6 +16,7 @@ const httpLink = new HttpLink({
   credentials: "include",
 });
 
+export const ERROR_BAD_CREDENTIALS = "Please enter valid credentials";
 export const ERROR_BAD_PERMISSIONS =
   "You do not have permission to perform this action";
 export const ERROR_NO_AUTH_TOKEN = "Token is required";

--- a/ui/src/client.test.js
+++ b/ui/src/client.test.js
@@ -1,21 +1,29 @@
+import React from "react";
+import { ApolloProvider } from "@apollo/react-hooks";
 import { graphql } from "msw";
+import { renderHook } from "@testing-library/react-hooks";
 
 import { server } from "./test-utils/server";
-import {
+import client, {
   ERROR_NO_AUTH_TOKEN,
   ERROR_NO_REFRESH_TOKEN,
+  ERROR_BAD_PERMISSIONS,
   handleBadPermissions,
 } from "./client";
 
 import authFetchers from "./authFetchers";
 import history from "./history";
+import { useUser } from "./user";
+import { RealAuthProvider } from "./auth";
+import { RealUserProvider } from "./user";
+import { mockUser, mockVerifyTokenSuccess } from "./test-utils/apiMocks";
 
 describe("handleBadPermissions", () => {
-  beforeAll(() => server.listen());
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-  test("works when both tokens are expired", async () => {
+  it("works when both tokens are expired", async () => {
     // specify api responses
     server.use(
       graphql.mutation("VerifyToken", (_, res, ctx) =>
@@ -38,5 +46,61 @@ describe("handleBadPermissions", () => {
     expect(authFetchers.verifyToken).toHaveBeenCalled();
     expect(authFetchers.refreshToken).toHaveBeenCalled();
     expect(history.push).toHaveBeenCalledWith("/");
+  });
+});
+
+describe("errorLink", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // helper
+  const wrapper = ({ children }) => (
+    <ApolloProvider client={client}>
+      <RealAuthProvider>
+        <RealUserProvider>{children}</RealUserProvider>
+      </RealAuthProvider>
+    </ApolloProvider>
+  );
+
+  it("successfully retries private query on successful auth token verification", async () => {
+    // specify initial api responses
+    server.use(
+      graphql.query("User", (_, res, ctx) =>
+        res(ctx.errors([{ message: ERROR_BAD_PERMISSIONS }]))
+      ),
+      graphql.mutation("VerifyToken", (_, res, ctx) =>
+        res(ctx.data({ verifyToken: mockVerifyTokenSuccess }))
+      )
+    );
+
+    // set up spies
+    jest.spyOn(authFetchers, "verifyToken");
+    jest.spyOn(authFetchers, "refreshToken");
+    jest.spyOn(history, "push");
+
+    // get context
+    const { result, waitForNextUpdate } = renderHook(() => useUser(), {
+      wrapper,
+    });
+
+    // act
+    result.current.getUser();
+    await waitForNextUpdate();
+
+    // assert
+    expect(result.current.user).toBeNull();
+    expect(authFetchers.verifyToken).toHaveBeenCalledTimes(1);
+
+    // specify new api response for retry
+    server.use(
+      graphql.query("User", (_, res, ctx) => res(ctx.data({ me: mockUser })))
+    );
+    await waitForNextUpdate();
+
+    // assert
+    expect(result.current.user).not.toBeNull();
+    expect(authFetchers.verifyToken).toHaveBeenCalledTimes(1);
+    expect(authFetchers.refreshToken).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/client.test.js
+++ b/ui/src/client.test.js
@@ -1,6 +1,6 @@
-import { server } from "./test-utils/server";
 import { graphql } from "msw";
 
+import { server } from "./test-utils/server";
 import {
   ERROR_NO_AUTH_TOKEN,
   ERROR_NO_REFRESH_TOKEN,

--- a/ui/src/components/Institutions.js
+++ b/ui/src/components/Institutions.js
@@ -30,7 +30,9 @@ export const INSTITUTIONS_QUERY = gql`
 `;
 
 const Institutions = () => {
-  const { loading, error, data } = useQuery(INSTITUTIONS_QUERY);
+  const { loading, error, data } = useQuery(INSTITUTIONS_QUERY, {
+    fetchPolicy: "network-only",
+  });
 
   let rows = [];
   if (data && !(loading || error)) {

--- a/ui/src/components/Institutions.js
+++ b/ui/src/components/Institutions.js
@@ -30,9 +30,7 @@ export const INSTITUTIONS_QUERY = gql`
 `;
 
 const Institutions = () => {
-  const { loading, error, data } = useQuery(INSTITUTIONS_QUERY, {
-    fetchPolicy: "network-only",
-  });
+  const { loading, error, data } = useQuery(INSTITUTIONS_QUERY);
 
   let rows = [];
   if (data && !(loading || error)) {

--- a/ui/src/components/Samples.js
+++ b/ui/src/components/Samples.js
@@ -71,7 +71,9 @@ export const SAMPLES_QUERY = gql`
 `;
 
 const Samples = () => {
-  const { loading, error, data } = useQuery(SAMPLES_QUERY);
+  const { loading, error, data } = useQuery(SAMPLES_QUERY, {
+    fetchPolicy: "network-only",
+  });
 
   let rows = [];
   if (data && !(loading || error)) {

--- a/ui/src/components/Samples.js
+++ b/ui/src/components/Samples.js
@@ -71,9 +71,7 @@ export const SAMPLES_QUERY = gql`
 `;
 
 const Samples = () => {
-  const { loading, error, data } = useQuery(SAMPLES_QUERY, {
-    fetchPolicy: "network-only",
-  });
+  const { loading, error, data } = useQuery(SAMPLES_QUERY);
 
   let rows = [];
   if (data && !(loading || error)) {

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -2,4 +2,20 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import "@testing-library/jest-dom/extend-expect";
+import { server } from "./test-utils/server";
+
+beforeAll(() => {
+  // Enable the mocking in tests.
+  server.listen();
+});
+
+afterEach(() => {
+  // Reset any runtime handlers tests may use.
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  // Clean up once the tests are done.
+  server.close();
+});

--- a/ui/src/test-utils/apiMocks.js
+++ b/ui/src/test-utils/apiMocks.js
@@ -1,7 +1,12 @@
 import { USER_QUERY } from "../user";
 import { SAMPLES_QUERY } from "../components/Samples";
 import { INSTITUTIONS_QUERY } from "../components/Institutions";
-import { LOGIN_MUTATION, LOGOUT_MUTATION } from "../auth";
+import {
+  LOGIN_MUTATION,
+  LOGOUT_MUTATION,
+  VERIFY_MUTATION,
+  REFRESH_MUTATION,
+} from "../auth";
 
 export const mockUser = {
   email: "admin@juno.com",
@@ -98,8 +103,12 @@ export const mockDefaults = {
   institutions: mockInstitutions,
   login: mockLoginSuccess,
   logout: mockLogoutSuccess,
+  verify: mockVerifyTokenSuccess,
+  refresh: mockRefreshTokenSuccess,
   loginErrors: null,
   logoutErrors: null,
+  verifyErrors: null,
+  refreshErrors: null,
 };
 export const generateApiMocks = (mocks = mockDefaults) => {
   const {
@@ -108,8 +117,12 @@ export const generateApiMocks = (mocks = mockDefaults) => {
     institutions,
     login,
     logout,
+    verify,
+    refresh,
     loginErrors,
     logoutErrors,
+    verifyErrors,
+    refreshErrors,
   } = mocks;
 
   // call counts for test assertions
@@ -119,6 +132,8 @@ export const generateApiMocks = (mocks = mockDefaults) => {
     institutionsQuery: 0,
     loginMutation: 0,
     logoutMutation: 0,
+    verifyMutation: 0,
+    refreshMutation: 0,
   };
 
   // combine data and errors
@@ -197,6 +212,24 @@ export const generateApiMocks = (mocks = mockDefaults) => {
         result: () => {
           called.logoutMutation += 1;
           return combine("deleteTokenCookie", logout, logoutErrors);
+        },
+      },
+      {
+        request: {
+          query: VERIFY_MUTATION,
+        },
+        result: () => {
+          called.verifyMutation += 1;
+          return combine("verifyToken", verify, verifyErrors);
+        },
+      },
+      {
+        request: {
+          query: REFRESH_MUTATION,
+        },
+        result: () => {
+          called.refreshMutation += 1;
+          return combine("refreshToken", refresh, refreshErrors);
         },
       },
     ],

--- a/ui/src/test-utils/apiMocks.js
+++ b/ui/src/test-utils/apiMocks.js
@@ -7,6 +7,7 @@ export const mockUser = {
   email: "admin@juno.com",
   firstName: "Han",
   lastName: "Solo",
+  __typename: "User",
 };
 
 export const mockSamples = [
@@ -69,6 +70,16 @@ export const mockLoginSuccess = {
 
 export const mockLogoutSuccess = {
   deleted: true,
+};
+
+export const mockVerifyTokenSuccess = {
+  payload: {
+    email: "gareth@juno.com",
+    exp: 1593794546,
+    origIat: 1593793946,
+    __typename: "GenericScalar",
+  },
+  __typename: "Verify",
 };
 
 export const mockDefaults = {

--- a/ui/src/test-utils/apiMocks.js
+++ b/ui/src/test-utils/apiMocks.js
@@ -82,6 +82,16 @@ export const mockVerifyTokenSuccess = {
   __typename: "Verify",
 };
 
+export const mockRefreshTokenSuccess = {
+  payload: {
+    email: "gareth@juno.com",
+    exp: 1593794546,
+    origIat: 1593793946,
+    __typename: "GenericScalar",
+  },
+  __typename: "Refresh",
+};
+
 export const mockDefaults = {
   user: mockUser,
   samples: mockSamples,

--- a/ui/src/test-utils/apiMocks.js
+++ b/ui/src/test-utils/apiMocks.js
@@ -77,9 +77,19 @@ export const mockDefaults = {
   institutions: mockInstitutions,
   login: mockLoginSuccess,
   logout: mockLogoutSuccess,
+  loginErrors: null,
+  logoutErrors: null,
 };
 export const generateApiMocks = (mocks = mockDefaults) => {
-  const { user, samples, institutions, login, logout } = mocks;
+  const {
+    user,
+    samples,
+    institutions,
+    login,
+    logout,
+    loginErrors,
+    logoutErrors,
+  } = mocks;
 
   // call counts for test assertions
   let called = {
@@ -89,6 +99,21 @@ export const generateApiMocks = (mocks = mockDefaults) => {
     loginMutation: 0,
     logoutMutation: 0,
   };
+
+  // combine data and errors
+  const combine = (dataFieldName, dataFieldValue, errors) => {
+    let result = {};
+    if (dataFieldValue) {
+      result.data = {
+        [dataFieldName]: dataFieldValue,
+      };
+    }
+    if (errors) {
+      result.errors = errors;
+    }
+    return result;
+  };
+
   return {
     called,
     mocks: [
@@ -141,11 +166,7 @@ export const generateApiMocks = (mocks = mockDefaults) => {
         },
         result: () => {
           called.loginMutation += 1;
-          return {
-            data: {
-              tokenAuth: login,
-            },
-          };
+          return combine("tokenAuth", login, loginErrors);
         },
       },
       {
@@ -154,11 +175,7 @@ export const generateApiMocks = (mocks = mockDefaults) => {
         },
         result: () => {
           called.logoutMutation += 1;
-          return {
-            data: {
-              deleteTokenCookie: logout,
-            },
-          };
+          return combine("deleteTokenCookie", logout, logoutErrors);
         },
       },
     ],

--- a/ui/src/user.js
+++ b/ui/src/user.js
@@ -6,7 +6,7 @@ import env from "./env";
 import { useAuth } from "./auth";
 
 export const USER_QUERY = gql`
-  {
+  query User {
     me {
       email
       firstName


### PR DESCRIPTION
This PR updates the handling of `samples` and `institutions` queries to restrict them based on the logged in user.