### PR TITLE
Use mounted S3 data

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ For the OpenStack instance, transfer this from your machine to the instance. Thi
 scp -r ./mock-data pathpipe@monocle.dev.pam.sanger.ac.uk:~/mock-data
 ```
 
+## Real data
+The real data files can be loaded from an S3 bucket, which is synced from farm5. If you have Sanger credentials, see the companion gitlab repo [monocle-farm5](https://gitlab.internal.sanger.ac.uk/sanger-pathogens/monocle-farm5).
+
 ## Testing
 There are currently:
 - integration tests in the `e2e` directory

--- a/README.md
+++ b/README.md
@@ -66,21 +66,10 @@ docker-compose -f docker-compose.dev.yml run <subcomponent> <command>
 ### Development directly on your development machine
 This requires a bit more setup, but may be easier to debug. Also, editor integration such as python linting/autocomplete may be easier to set up. Read about setting up the [ui](ui/README.md) and [api](api/README.md) separately.
 
-## Mock data
-**Note: This section is temporary and is intended to be removed.**
+## Data
+In production, the real data files are loaded from an S3 bucket, which is synced from farm5. If you have Sanger credentials, see the companion gitlab repo [monocle-farm5](https://gitlab.internal.sanger.ac.uk/sanger-pathogens/monocle-farm5).
 
-For development of the download functionality, please load the following sample lane.
-```
-scp -r <you>@pcs6:/lustre/scratch118/infgen/pathogen/pathpipe/prokaryotes/seq-pipelines/Streptococcus/agalactiae/TRACKING/5903/5903STDY8059170/SLX/23800977/31663_7#113 ./mock-data/
-```
-
-For the OpenStack instance, transfer this from your machine to the instance. This should only need to be done once after the instance is created.
-```
-scp -r ./mock-data pathpipe@monocle.dev.pam.sanger.ac.uk:~/mock-data
-```
-
-## Real data
-The real data files can be loaded from an S3 bucket, which is synced from farm5. If you have Sanger credentials, see the companion gitlab repo [monocle-farm5](https://gitlab.internal.sanger.ac.uk/sanger-pathogens/monocle-farm5).
+For development and testing, lightweight mock data for a single lane is used. See the `mock-data` directory within the repo.
 
 ## Testing
 There are currently:

--- a/api/juno/api/downloads.py
+++ b/api/juno/api/downloads.py
@@ -1,22 +1,32 @@
-import tarfile, io, os
+import io
+import os
+import tarfile
 from django.conf import settings
 
-# TODO: replace fixed mock file with actual file for lane
-DATA_DIR = os.path.join(
-    os.path.join(getattr(settings, "BASE_DIR", None), os.pardir),
-    "mock-data/" + "31663_7#113",
-)
+
+def get_renamings(lane_id):
+    read1 = lane_id + "_1.fastq.gz"
+    read2 = lane_id + "_2.fastq.gz"
+    annotation = "spades_assembly/annotation/" + lane_id + ".gff"
+    return {
+        read1: read1,
+        read2: read2,
+        "spades_assembly/contigs.fa": "spades_contigs.fa",
+        annotation: "spades_annotation.gff",
+    }
 
 
 def make_tarfile(lane_id):
-    lane_dir = os.path.abspath(DATA_DIR)
-    # TODO: change this list to take in lane id
-    filenames = {
-        "31663_7#113_1.fastq.gz": "31663_7#113_1.fastq.gz",
-        "31663_7#113_2.fastq.gz": "31663_7#113_2.fastq.gz",
-        "spades_assembly/contigs.fa": "spades_contigs.fa",
-        "spades_assembly/annotation/31663_7#113.gff": "spades_annotation.gff",
-    }
+    if settings.USE_MOCK_LANE_DATA:
+        mock_lane_id = "31663_7#113"
+        lane_dir = os.path.abspath(
+            os.path.join(settings.DATA_DIR, mock_lane_id)
+        )
+        filenames = get_renamings(mock_lane_id)
+    else:
+        lane_dir = os.path.abspath(os.path.join(settings.DATA_DIR, lane_id))
+        filenames = get_renamings(lane_id)
+
     out_file = io.BytesIO()
     with tarfile.open(fileobj=out_file, mode="w:gz") as tar:
         for file in filenames:

--- a/api/juno/asgi.py
+++ b/api/juno/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'juno.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "juno.settings.prod")
 
 application = get_asgi_application()

--- a/api/juno/settings/common.py
+++ b/api/juno/settings/common.py
@@ -14,23 +14,12 @@ import os
 from datetime import timedelta
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "@7ad3g19au9^xhh3r&o^g!_g8h=%1di2&!ns&h*xy@tcqk#e9+"
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = [
-    "localhost",
-    "api",
-    "127.0.0.1",
-    "monocle.dev.pam.sanger.ac.uk",
-]
 
 
 # Application definition
@@ -99,9 +88,15 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
-    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
 ]
 
 
@@ -121,27 +116,29 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
-
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
+
+# CORS
+CORS_ORIGIN_ALLOW_ALL = True  # If this is used then `CORS_ORIGIN_WHITELIST` will not have any effect
+CORS_ALLOW_CREDENTIALS = True
+# CORS_ORIGIN_WHITELIST = ("http://localhost:3000",)
+
+
+# GraphQL
 GRAPHENE = {
     "SCHEMA": "juno.schema.schema",
     "MIDDLEWARE": ["graphql_jwt.middleware.JSONWebTokenMiddleware"],
 }
 
-CORS_ORIGIN_ALLOW_ALL = (
-    True  # If this is used then `CORS_ORIGIN_WHITELIST` will not have any effect
-)
-CORS_ALLOW_CREDENTIALS = True
-# CORS_ORIGIN_WHITELIST = ("http://localhost:3000",)
 
+# GraphQL authentication
 AUTH_USER_MODEL = "api.User"
 AUTHENTICATION_BACKENDS = [
     "graphql_jwt.backends.JSONWebTokenBackend",
     "django.contrib.auth.backends.ModelBackend",
 ]
-
 GRAPHQL_JWT = {
     "JWT_VERIFY_EXPIRATION": True,
     "JWT_EXPIRATION_DELTA": timedelta(minutes=10),

--- a/api/juno/settings/dev.py
+++ b/api/juno/settings/dev.py
@@ -1,0 +1,15 @@
+import os
+
+from juno.settings.common import *
+from juno.settings import common
+
+DEBUG = True
+SECRET_KEY = "@7ad3g19au9^xhh3r&o^g!_g8h=%1di2&!ns&h*xy@tcqk#e9+"
+ALLOWED_HOSTS = [
+    "localhost",
+    "127.0.0.1",
+]
+DATA_DIR = os.path.join(
+    os.path.join(getattr(common, "BASE_DIR", None), os.pardir), "mock-data/",
+)
+USE_MOCK_LANE_DATA = True

--- a/api/juno/settings/e2e.py
+++ b/api/juno/settings/e2e.py
@@ -1,0 +1,10 @@
+from juno.settings.common import *
+
+DEBUG = False
+SECRET_KEY = "@7ad3g19au9^xhh3r&o^g!_g8h=%1di2&!ns&h*xy@tcqk#e9+"
+ALLOWED_HOSTS = [
+    "localhost",
+    "127.0.0.1",
+]
+DATA_DIR = "/data"
+USE_MOCK_LANE_DATA = True

--- a/api/juno/settings/prod.py
+++ b/api/juno/settings/prod.py
@@ -1,0 +1,14 @@
+from juno.settings.common import *
+
+# TODO: Set production SECRET_KEY
+# TODO: Set production CORS_ORIGIN_WHITELIST
+
+DEBUG = False
+SECRET_KEY = "@7ad3g19au9^xhh3r&o^g!_g8h=%1di2&!ns&h*xy@tcqk#e9+"
+ALLOWED_HOSTS = [
+    "localhost",
+    "127.0.0.1",
+    "monocle.dev.pam.sanger.ac.uk",
+]
+DATA_DIR = "/data"
+USE_MOCK_LANE_DATA = False

--- a/api/juno/tests/test_download_sample.py
+++ b/api/juno/tests/test_download_sample.py
@@ -2,8 +2,6 @@ import io
 import os
 import tarfile
 import unittest
-
-# from django.test import override_settings
 from django.conf import settings
 from testfixtures import TempDirectory
 

--- a/api/juno/tests/test_download_sample.py
+++ b/api/juno/tests/test_download_sample.py
@@ -1,36 +1,58 @@
-from juno.api import downloads
+import io
+import os
+import tarfile
 import unittest
+
+# from django.test import override_settings
+from django.conf import settings
 from testfixtures import TempDirectory
-import tarfile, io, os
+
+from juno.api import downloads
 
 
-class TestDownload(unittest.TestCase):
+class TestMakeTarfile(unittest.TestCase):
     def setUp(self):
-        self.tempdir = TempDirectory()
-        self.tempdir_path = self.tempdir.path
-        downloads.DATA_DIR = self.tempdir_path
+        # create DATA_DIR
+        self.data_dir = TempDirectory()
+
+        # create single lane directory
+        self.lane_id = "31663_7#113"
+        # self.lane_dir = self.data_dir.makedir(self.lane_id)
+
+        # create mock files for single lane
+        self.files = [
+            self.lane_id + "_1.fastq.gz",
+            self.lane_id + "_2.fastq.gz",
+            "spades_assembly/contigs.fa",
+            "spades_assembly/annotation/" + self.lane_id + ".gff",
+        ]
+        for filename in self.files:
+            self.data_dir.write(
+                "/".join([self.lane_id, filename]), b"some data"
+            )
+
+        # override settings
+        settings.DATA_DIR = self.data_dir.path
+        settings.USE_MOCK_LANE_DATA = False
 
     def tearDown(self):
-        self.tempdir.cleanup()
-        pass
+        self.data_dir.cleanup()
 
-    def test_make_tarfile_returns_bytes_like_object(self):
-        files = [
-            "31663_7#113_1.fastq.gz",
-            "31663_7#113_2.fastq.gz",
-            "spades_assembly/contigs.fa",
-            "spades_assembly/annotation/31663_7#113.gff",
-        ]
-        for file in files:
-            self.tempdir.write(file, b"some data")
-        tar_file = downloads.make_tarfile(self.tempdir_path)
+    def test_returns_bytes_for_valid_lane(self):
+        tar_file = downloads.make_tarfile(self.lane_id)
+
+        # file?
         self.assertIsInstance(tar_file.getvalue(), bytes)
+
+        # tarfile?
         file_in = io.BytesIO(tar_file.getvalue())
         tar = tarfile.open(mode="r:gz", fileobj=file_in)
-        tar.extractall(self.tempdir_path + "/extract/")
-        for file in files:
-            os.path.isfile(self.tempdir_path + "/extract/" + file)
+        tar.extractall(self.lane_id + "/extract/")
 
-    def test_make_tarfile_returns_filenotfound(self):
+        # contains individual data files?
+        for file in self.files:
+            os.path.isfile(self.lane_id + "/extract/" + file)
+
+    def test_raises_filenotfound_for_invalid_lane(self):
         with self.assertRaises(FileNotFoundError):
-            downloads.make_tarfile(self.tempdir_path)
+            downloads.make_tarfile("invalid_lane_id")

--- a/api/juno/tests/test_download_sample.py
+++ b/api/juno/tests/test_download_sample.py
@@ -15,9 +15,11 @@ class TestMakeTarfile(unittest.TestCase):
         # create DATA_DIR
         self.data_dir = TempDirectory()
 
+        # create extraction directory
+        self.extract_dir = TempDirectory()
+
         # create single lane directory
         self.lane_id = "31663_7#113"
-        # self.lane_dir = self.data_dir.makedir(self.lane_id)
 
         # create mock files for single lane
         self.files = [
@@ -37,6 +39,7 @@ class TestMakeTarfile(unittest.TestCase):
 
     def tearDown(self):
         self.data_dir.cleanup()
+        self.extract_dir.cleanup()
 
     def test_returns_bytes_for_valid_lane(self):
         tar_file = downloads.make_tarfile(self.lane_id)
@@ -47,11 +50,12 @@ class TestMakeTarfile(unittest.TestCase):
         # tarfile?
         file_in = io.BytesIO(tar_file.getvalue())
         tar = tarfile.open(mode="r:gz", fileobj=file_in)
-        tar.extractall(self.lane_id + "/extract/")
+
+        tar.extractall(self.extract_dir.path + "/extract/")
 
         # contains individual data files?
-        for file in self.files:
-            os.path.isfile(self.lane_id + "/extract/" + file)
+        for filename in self.files:
+            os.path.isfile(self.extract_dir.path + "/extract/" + filename)
 
     def test_raises_filenotfound_for_invalid_lane(self):
         with self.assertRaises(FileNotFoundError):

--- a/api/juno/wsgi.py
+++ b/api/juno/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'juno.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "juno.settings.prod")
 
 application = get_wsgi_application()

--- a/api/manage.py
+++ b/api/manage.py
@@ -5,7 +5,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'juno.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "juno.settings.dev")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -17,5 +17,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,4 +21,4 @@ services:
         - "8000:8000"
     volumes:
         - ./api:/app
-        - ./mock-data/:/mock-data/
+        - ./mock-data:/data

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -16,4 +16,6 @@ services:
     ports:
       - "8001:80"
     volumes:
-      - ./mock-data/:/mock-data/
+      - ./mock-data:/data
+    environment:
+      - DJANGO_SETTINGS_MODULE=juno.settings.e2e

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,4 +14,11 @@ services:
     ports:
         - "8000:80"
     volumes:
-        - ./mock-data/:/mock-data/
+        - data:/mock-data
+volumes:
+    data:
+        driver: local
+        driver_opts:
+            o: bind
+            type: none
+            device: /home/pathpipe/monocle_juno_test

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,7 +14,9 @@ services:
     ports:
         - "8000:80"
     volumes:
-        - data:/mock-data
+        - data:/data
+    environment:
+        - DJANGO_SETTINGS_MODULE=juno.settings.production
 volumes:
     data:
         driver: local

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,0 +1,28 @@
+# Sync
+
+Below is a brief overview of Monocle's data sync process and the setup required on the OpenStack instance.
+
+## Components
+The main components of Monocle run on OpenStack, but the primary copies of the served data files live on the farm. Files can be shared between the farm and OpenStack by pushing to and then mounting a Ceph S3 bucket.
+
+[![](https://mermaid.ink/img/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtXG4gICAgcGFydGljaXBhbnQgcGF0aHBpcGVAZmFybTVcbiAgICBwYXJ0aWNpcGFudCBTM1xuICAgIHBhcnRpY2lwYW50IHBhdGhwaXBlQGZjZV9pbnN0YW5jZVxuICAgIHBhcnRpY2lwYW50IGNvbnRhaW5lclxuICAgIE5vdGUgb3ZlciBwYXRocGlwZUBmYXJtNSwgUzM6IGNyb25cbiAgICBTMy0-PnBhdGhwaXBlQGZjZV9pbnN0YW5jZTogcmNsb25lIG1vdW50IC0tcmVhZC1vbmx5XG4gICAgcGF0aHBpcGVAZmNlX2luc3RhbmNlLT4-Y29udGFpbmVyOiB2b2x1bWUgbW91bnRcblx0cGF0aHBpcGVAZmFybTUtPj5TMzogcmNsb25lIHN5bmNcbiAgICBwYXRocGlwZUBmYXJtNS0-PlMzOiByY2xvbmUgc3luY1xuICAgIHBhdGhwaXBlQGZhcm01LT4-UzM6IHJjbG9uZSBzeW5jXG4gICAgTm90ZSBvdmVyIHBhdGhwaXBlQGZjZV9pbnN0YW5jZSwgY29udGFpbmVyOiBkZXBsb3kgbmV3IHJlbGVhc2VcbiAgICBwYXRocGlwZUBmY2VfaW5zdGFuY2UtPj5jb250YWluZXI6IHZvbHVtZSBtb3VudFxuXG5cdFx0XHRcdFx0IiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifSwidXBkYXRlRWRpdG9yIjpmYWxzZX0)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtXG4gICAgcGFydGljaXBhbnQgcGF0aHBpcGVAZmFybTVcbiAgICBwYXJ0aWNpcGFudCBTM1xuICAgIHBhcnRpY2lwYW50IHBhdGhwaXBlQGZjZV9pbnN0YW5jZVxuICAgIHBhcnRpY2lwYW50IGNvbnRhaW5lclxuICAgIE5vdGUgb3ZlciBwYXRocGlwZUBmYXJtNSwgUzM6IGNyb25cbiAgICBTMy0-PnBhdGhwaXBlQGZjZV9pbnN0YW5jZTogcmNsb25lIG1vdW50IC0tcmVhZC1vbmx5XG4gICAgcGF0aHBpcGVAZmNlX2luc3RhbmNlLT4-Y29udGFpbmVyOiB2b2x1bWUgbW91bnRcblx0cGF0aHBpcGVAZmFybTUtPj5TMzogcmNsb25lIHN5bmNcbiAgICBwYXRocGlwZUBmYXJtNS0-PlMzOiByY2xvbmUgc3luY1xuICAgIHBhdGhwaXBlQGZhcm01LT4-UzM6IHJjbG9uZSBzeW5jXG4gICAgTm90ZSBvdmVyIHBhdGhwaXBlQGZjZV9pbnN0YW5jZSwgY29udGFpbmVyOiBkZXBsb3kgbmV3IHJlbGVhc2VcbiAgICBwYXRocGlwZUBmY2VfaW5zdGFuY2UtPj5jb250YWluZXI6IHZvbHVtZSBtb3VudFxuXG5cdFx0XHRcdFx0IiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifSwidXBkYXRlRWRpdG9yIjpmYWxzZX0)
+
+## Setup on OpenStack instance
+
+### Prerequisites
+The following steps are needed on a fresh OpenStack instance. Ideally, they should be run automatically when provisioning in the future.
+- install [rclone](https://rclone.org/)
+- add `~/.config/rclone/rclone.conf` with identical content to on `pathpipe@farm5` (contains S3 secrets/keys, hence not in repo)
+- ensure `/etc/fuse.conf` contains the line `user_allow_other` (which allows users other than the mounting user to access files on the instance; needed for Docker)
+
+### Mount
+Given a Ceph S3 origin (named `remote` from `rclone.conf`), mount the bucket `<bucket-name>` with:
+```
+rclone mount remote:<bucket-name> <local-dir> --read-only --allow-other --allow-root --vfs-cache-mode writes --daemon
+```
+
+### Unmount
+Run:
+```
+fusermount -u <local-dir>
+```

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -18,11 +18,13 @@ The following steps are needed on a fresh OpenStack instance. Ideally, they shou
 ### Mount
 Given a Ceph S3 origin (named `remote` from `rclone.conf`), mount the bucket `<bucket-name>` with:
 ```
-rclone mount remote:<bucket-name> <local-dir> --read-only --allow-other --allow-root --vfs-cache-mode writes --daemon
+# rclone mount remote:<bucket-name> <local-dir> --read-only --allow-other --allow-root --vfs-cache-mode writes --daemon
+rclone mount remote:monocle_juno_test /home/pathpipe/monocle_juno_test --read-only --allow-other --allow-root --vfs-cache-mode writes --daemon
 ```
 
 ### Unmount
 Run:
 ```
-fusermount -u <local-dir>
+# fusermount -u <local-dir>
+fusermount -u /home/pathpipe/monocle_juno_test
 ```


### PR DESCRIPTION
This PR:
- separates out the `api` component's settings file for development, production and e2e scenarios
- mounts data files into the `api` container at `/data` (assuming existance of long running mount on OpenStack VM)
- updates unit and e2e tests accordingly