### PR TITLE
Update deployment

### DIFF
--- a/api/juno/settings/dev.py
+++ b/api/juno/settings/dev.py
@@ -1,7 +1,7 @@
 import os
 
-from juno.settings.common import *
-from juno.settings import common
+from .common import *
+from . import common
 
 DEBUG = True
 SECRET_KEY = "@7ad3g19au9^xhh3r&o^g!_g8h=%1di2&!ns&h*xy@tcqk#e9+"

--- a/api/juno/settings/e2e.py
+++ b/api/juno/settings/e2e.py
@@ -1,4 +1,4 @@
-from juno.settings.common import *
+from .common import *
 
 DEBUG = False
 SECRET_KEY = "@7ad3g19au9^xhh3r&o^g!_g8h=%1di2&!ns&h*xy@tcqk#e9+"

--- a/api/juno/settings/prod.py
+++ b/api/juno/settings/prod.py
@@ -1,5 +1,5 @@
 import environ
-from juno.settings.common import *
+from .common import *
 
 # TODO: Set production CORS_ORIGIN_WHITELIST
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -42,13 +42,10 @@ ssh -o ControlPath=%C $REMOTE_USER@$REMOTE_HOST << EOF
     echo "Stopping existing containers..."
     docker-compose down
 
-    # load secrets from host
-    source ~/.monocle-secrets
-
     echo "Setting configuration in docker-compose.yml..."
     sed -i -e "s/<VERSION>/${VERSION}/g" docker-compose.yml
     sed -i -e "s/<HOSTNAME>/${REMOTE_HOST}/g" docker-compose.yml
-    sed -i -e "s/<SECRET_KEY>/${API_SECRET_KEY}/g" docker-compose.yml
+    sed -i -e "s/<SECRET_KEY>/\${API_SECRET_KEY}/g" docker-compose.yml
     
     echo "Setting configuration in UI's settings.js..."
     sed -i -e "s/<HOSTNAME>/${REMOTE_HOST}/g" settings.js

--- a/deploy.sh
+++ b/deploy.sh
@@ -38,6 +38,9 @@ scp -o ControlPath=%C ui/nginx.prod.conf $REMOTE_USER@$REMOTE_HOST:~/nginx.conf
 
 # replace the running version
 # using existing connection
+# note: local variables are substituted as normal,
+#       remote variables need escaping
+#       (eg. VERSION vs API_SECRET_KEY)
 ssh -o ControlPath=%C $REMOTE_USER@$REMOTE_HOST << EOF
     echo "Stopping existing containers..."
     docker-compose down

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,7 @@ services:
     environment:
         - HOSTNAME=<HOSTNAME>
         - SECRET_KEY=<SECRET_KEY>
-        - DJANGO_SETTINGS_MODULE=juno.settings.production
+        - DJANGO_SETTINGS_MODULE=juno.settings.prod
 volumes:
     data:
         driver: local

--- a/docs/secret-key.md
+++ b/docs/secret-key.md
@@ -1,9 +1,18 @@
 # Secret keys
 In production, Django needs a `SECRET_KEY` setting, which should not be stored in version control.
 
-At present, this is loaded on deployment from a file `/home/pathpipe/.monocle-secrets` on the OpenStack VM, which has the following format:
+At present, this is loaded on deployment from a file `/home/pathpipe/.ssh/environment` on the OpenStack VM, which has the following format:
 ```
-export SECRET_KEY="<some-string-of-50-random-characters>"
+API_SECRET_KEY=<some-string-of-50-random-alphanumeric-characters>
 ```
 
-To generate a new string, you could use eg. `base64 /dev/urandom | head -c50`.
+## Allowing ssh remote environments
+To enable one or more remote environment variables (from `~/.ssh/environment`) to be loaded when `ssh`ing into the OpenStack VM, add the following line to `etc/ssh/sshd_config` if not present:
+```
+PermitUserEnvironment yes
+```
+
+Restart the service:
+```
+sudo service sshd restart
+```


### PR DESCRIPTION
This PR:
- fixes a configuration typo
- uses `.ssh/environment` to load a secret from the OpenStack VM